### PR TITLE
Add launch test for arm CCA

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -5,4 +5,11 @@ use vmm_sys_util::errno;
 #[derive(Debug)]
 pub enum Error {
     VmCreate(errno::Error),
+    GICCreate(errno::Error),
+    GICInit(errno::Error),
+    Config(errno::Error),
+    RDCreate(errno::Error),
+    RPopulate(errno::Error),
+    RInitiate(errno::Error),
+    RActivate(errno::Error),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,15 +6,24 @@ pub mod error;
 
 use error::*;
 
-use std::cmp::max;
+use std::ptr;
 
 use kvm_bindings::*;
 use kvm_ioctls::{Cap, Kvm, VmFd};
 
-pub struct Realm {
-    vm_fd: VmFd,
-    ipa_bits: u32,
+pub struct Realm;
+
+pub enum Algo {
+    AlgoSha256,
+    AlgoSha512,
 }
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub const ARM_GIC_REDIST_SIZE: u64 = 0x20000;
+pub const ARM_GIC_DIST_SIZE: u64 = 0x10000;
+pub const ARM_AXI_AREA: u64 = 0x40000000;
+pub const ARM_GIC_DIST_BASE: u64 = ARM_AXI_AREA - ARM_GIC_DIST_SIZE;
 
 impl Realm {
     // Check if the ARM Realm Management Extension (RME) is supported. This capability is required
@@ -23,21 +32,79 @@ impl Realm {
         kvm.check_extension(Cap::ArmRme)
     }
 
-    // Given the maximum IPA space needed, create a realm VM.
-    pub fn new(kvm: &Kvm, max_ipa: usize) -> Result<Self, Error> {
-        let ipa_bits = max(1 << max_ipa.trailing_zeros(), 32) + 1;
-
-        let vm_fd = kvm
-            .create_vm_with_type(
-                (KVM_VM_TYPE_ARM_REALM | (ipa_bits & KVM_VM_TYPE_ARM_IPA_SIZE_MASK)).into(),
-            )
-            .map_err(Error::VmCreate)?;
-
-        Ok(Self { vm_fd, ipa_bits })
+    pub fn new() -> Self {
+        Self {}
     }
 
-    // Fetch the realm's underlying VM file descriptor.
-    pub fn vm_fd(&mut self) -> &mut VmFd {
-        &mut self.vm_fd
+    pub fn configure_measurement(&self, vmfd: &VmFd, _algo: Algo) -> Result<()> {
+        let mut hash_algo_cfg = kvm_cap_arm_rme_config_item {
+            cfg: KVM_CAP_ARM_RME_CFG_HASH_ALGO,
+            ..Default::default()
+        };
+
+        hash_algo_cfg.data.hash_algo = KVM_CAP_ARM_RME_MEASUREMENT_ALGO_SHA256;
+
+        let mut rme_config = kvm_enable_cap {
+            cap: KVM_CAP_ARM_RME,
+            ..Default::default()
+        };
+
+        rme_config.args[0] = KVM_CAP_ARM_RME_CONFIG_REALM;
+        rme_config.args[1] = ptr::addr_of!(hash_algo_cfg) as u64;
+
+        vmfd.enable_cap(&rme_config).map_err(Error::Config)?;
+
+        Ok(())
+    }
+
+    pub fn create_realm_descriptor(&self, vmfd: &VmFd) -> Result<()> {
+        let mut rme_config = kvm_enable_cap {
+            cap: KVM_CAP_ARM_RME,
+            ..Default::default()
+        };
+
+        rme_config.args[0] = KVM_CAP_ARM_RME_CREATE_RD;
+        vmfd.enable_cap(&rme_config).map_err(Error::RDCreate)?;
+
+        Ok(())
+    }
+
+    pub fn populate(&self, vmfd: &VmFd, addr: u64, size: u64) -> Result<()> {
+        let mut populate_args: kvm_cap_arm_rme_populate_realm_args = Default::default();
+        let mut rme_config = kvm_enable_cap {
+            cap: KVM_CAP_ARM_RME,
+            ..Default::default()
+        };
+        populate_args.populate_ipa_base = addr;
+        populate_args.populate_ipa_size = size;
+        populate_args.flags = KVM_ARM_RME_POPULATE_FLAGS_MEASURE;
+        rme_config.args[0] = KVM_CAP_ARM_RME_POPULATE_REALM;
+        rme_config.args[1] = ptr::addr_of!(populate_args) as u64;
+        vmfd.enable_cap(&rme_config).map_err(Error::RPopulate)?;
+        Ok(())
+    }
+
+    pub fn initiate(&self, vmfd: &VmFd, addr: u64, size: u64) -> Result<()> {
+        let mut init_args: kvm_cap_arm_rme_init_ipa_args = Default::default();
+        let mut rme_config = kvm_enable_cap {
+            cap: KVM_CAP_ARM_RME,
+            ..Default::default()
+        };
+        init_args.init_ipa_base = addr;
+        init_args.init_ipa_size = size;
+        rme_config.args[0] = KVM_CAP_ARM_RME_INIT_IPA_REALM;
+        rme_config.args[1] = ptr::addr_of!(init_args) as u64;
+        vmfd.enable_cap(&rme_config).map_err(Error::RInitiate)?;
+        Ok(())
+    }
+
+    pub fn activate(&self, vmfd: &VmFd) -> Result<()> {
+        let mut rme_config = kvm_enable_cap {
+            cap: KVM_CAP_ARM_RME,
+            ..Default::default()
+        };
+        rme_config.args[0] = KVM_CAP_ARM_RME_ACTIVATE_REALM;
+        vmfd.enable_cap(&rme_config).map_err(Error::RActivate)?;
+        Ok(())
     }
 }

--- a/tests/launch.rs
+++ b/tests/launch.rs
@@ -1,43 +1,169 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::slice::from_raw_parts_mut;
+use std::{cmp::max, os::fd::RawFd, ptr};
 
-use cca::Realm;
-use kvm_bindings::{kvm_userspace_memory_region, KVM_MEM_GUEST_MEMFD};
-use kvm_ioctls::Kvm;
+use cca::{Algo, Realm, ARM_GIC_DIST_BASE, ARM_GIC_REDIST_SIZE};
+use kvm_bindings::*;
 
-// One page of `hlt` instructions.
-const CODE: &[u8; 4096] = &[0xf4; 4096];
+use kvm_ioctls::{Kvm, VcpuExit};
 
 #[test]
 fn launch() {
     let kvm = Kvm::new().unwrap();
 
+    let code = [
+        0x01, 0x00, 0x00, 0xf9, /* str x1, [x0] */
+        0x00, 0x00, 0x00,
+        0x14, /* b <this address>; shouldn't get here, but if so loop forever */
+    ];
+
     assert_eq!(Realm::supported(&kvm), true);
 
-    let mut realm = Realm::new(&kvm, 32).unwrap();
+    const MEM_ADDR: u64 = 0x10000;
 
-    let address_space = unsafe { libc::mmap(0 as _, CODE.len(), 3, 34, -1, 0) };
+    const CODE_SIZE: u64 = 0x1000;
+
+    let max_ipa = MEM_ADDR + CODE_SIZE as u64 - 1;
+    let ipa_bits = max(1 << max_ipa.trailing_zeros(), 32) + 1;
+
+    let vm_fd = kvm
+        .create_vm_with_type(
+            (KVM_VM_TYPE_ARM_REALM | (ipa_bits & KVM_VM_TYPE_ARM_IPA_SIZE_MASK)).into(),
+        )
+        .unwrap();
+
+    let realm = Realm::new();
+
+    // Create IRQ chip in kernel: IRQCHIP_GICV3
+    let mut gic_device = kvm_create_device {
+        type_: kvm_device_type_KVM_DEV_TYPE_ARM_VGIC_V3,
+        fd: 0,
+        flags: 0,
+    };
+
+    let gic_fd = vm_fd.create_device(&mut gic_device).unwrap();
+
+    // "1" is the number of vcpus
+    let gic_redists_size: u64 = 1u64 * ARM_GIC_REDIST_SIZE;
+    let gic_redists_base: u64 = ARM_GIC_DIST_BASE - gic_redists_size;
+
+    let redist_attr = kvm_device_attr {
+        flags: 0,
+        group: KVM_DEV_ARM_VGIC_GRP_ADDR,
+        attr: u64::from(KVM_VGIC_V3_ADDR_TYPE_REDIST),
+        addr: ptr::addr_of!(gic_redists_base) as u64,
+    };
+
+    gic_fd.set_device_attr(&redist_attr).unwrap();
+
+    let dist_addr: u64 = ARM_GIC_DIST_BASE;
+    let dist_attr = kvm_device_attr {
+        flags: 0,
+        group: KVM_DEV_ARM_VGIC_GRP_ADDR,
+        attr: u64::from(KVM_VGIC_V3_ADDR_TYPE_DIST),
+        addr: ptr::addr_of!(dist_addr) as u64,
+    };
+
+    gic_fd.set_device_attr(&dist_attr).unwrap();
+
+    let address_space = unsafe { libc::mmap(0 as _, CODE_SIZE.try_into().unwrap(), 3, 34, -1, 0) };
     if address_space == libc::MAP_FAILED {
         panic!("mmap() failed");
     }
 
     let address_space: &mut [u8] =
-        unsafe { from_raw_parts_mut(address_space as *mut u8, CODE.len()) };
+        unsafe { from_raw_parts_mut(address_space as *mut u8, code.len()) };
 
-    address_space[..CODE.len()].copy_from_slice(&CODE[..]);
+    address_space[..code.len()].copy_from_slice(&code[..]);
 
-    const MEM_ADDR: u64 = 0x1000;
     let userspace_addr = address_space as *const [u8] as *const u8 as u64;
-    let mem_region = kvm_userspace_memory_region {
+
+    let gmem = kvm_create_guest_memfd {
+        size: CODE_SIZE,
+        flags: 0,
+        reserved: [0; 6],
+    };
+
+    let id: RawFd = vm_fd.create_guest_memfd(gmem).unwrap();
+
+    let mem_region = kvm_userspace_memory_region2 {
         slot: 0,
-        guest_phys_addr: MEM_ADDR,
-        memory_size: CODE.len() as _,
-        userspace_addr,
         flags: KVM_MEM_GUEST_MEMFD,
+        guest_phys_addr: MEM_ADDR,
+        memory_size: CODE_SIZE,
+        userspace_addr,
+        guest_memfd_offset: 0,
+        guest_memfd: id as u32,
+        pad1: 0,
+        pad2: [0; 14],
     };
 
     unsafe {
-        realm.vm_fd().set_user_memory_region(mem_region).unwrap();
+        vm_fd.set_user_memory_region2(mem_region).unwrap();
+    }
+
+    let mut vcpu_fd = vm_fd.create_vcpu(0).unwrap();
+
+    let mut kvi = kvm_vcpu_init::default();
+    vm_fd.get_preferred_target(&mut kvi).unwrap();
+
+    kvi.features[0] |= 1u32 << KVM_ARM_VCPU_PSCI_0_2;
+
+    vcpu_fd.vcpu_init(&kvi).unwrap();
+
+    // initialize vGiC after VCPU creation. Note that this is a minimal setup
+    let vgic_init_attr = kvm_device_attr {
+        flags: 0,
+        group: KVM_DEV_ARM_VGIC_GRP_CTRL,
+        attr: u64::from(KVM_DEV_ARM_VGIC_CTRL_INIT),
+        addr: 0x0,
+    };
+
+    gic_fd.set_device_attr(&vgic_init_attr).unwrap();
+
+    realm
+        .configure_measurement(&vm_fd, Algo::AlgoSha256)
+        .unwrap();
+
+    realm.create_realm_descriptor(&vm_fd).unwrap();
+
+    realm.populate(&vm_fd, MEM_ADDR, CODE_SIZE as u64).unwrap();
+
+    let core_reg_base: u64 = 0x6030_0000_0010_0000;
+
+    // set x1 to known value
+    let nr_magic: u64 = 0x1987;
+    vcpu_fd
+        .set_one_reg(core_reg_base + 2 * 1, &(nr_magic as u128).to_le_bytes())
+        .unwrap();
+
+    // set x0 to a mmio region out of ipa
+    let mmio_addr: u64 = (1 << ipa_bits - 1) + 0x1000;
+    vcpu_fd
+        .set_one_reg(core_reg_base + 2 * 0, &(mmio_addr as u128).to_le_bytes())
+        .unwrap();
+
+    // set pc
+    let guest_addr: u64 = MEM_ADDR;
+    vcpu_fd
+        .set_one_reg(core_reg_base + 2 * 32, &(guest_addr as u128).to_le_bytes())
+        .unwrap();
+
+    let feature = KVM_ARM_VCPU_REC as i32;
+    vcpu_fd.vcpu_finalize(&feature).unwrap();
+
+    realm.activate(&vm_fd).unwrap();
+
+    loop {
+        match vcpu_fd.run().expect("run failed") {
+            VcpuExit::MmioWrite(addr, data) => {
+                assert_eq!(addr, 0x1000);
+                assert_eq!(data[0], 0x87);
+                assert_eq!(data[1], 0x19);
+                break;
+            }
+            exit_reason => panic!("unexpected exit reason: {:?}", exit_reason),
+        }
     }
 }


### PR DESCRIPTION
This has been tested by using the FVP model and the v3 series. This procedure requires docker installed in the host. To try it in a arm64 machine (you can find a procedure to try in x86 at [4]), you can:
- Install shrinkwrap:
```bash
pip install pyyaml termcolor tuxmake
git clone https://git.gitlab.arm.com/tooling/shrinkwrap.git
export PATH=$PWD/shrinkwrap/shrinkwrap:$PATH
```
- Build the model and its components:
```bash
shrinkwrap build cca-3world.yaml --overlay buildroot.yaml --overlay cca-v3.yaml 
```
, where `cca-v3.yaml` is:
```
build:
  linux:
    repo:
      revision: cca-full/v3
  kvmtool:
    repo:
      kvmtool:
        revision: cca/v2
  rmm:
    repo:
      revision: main
  kvm-unit-tests:
    repo:
      revision: cca/v2
```
- Compile the launch test. To do this, you have to use `kvm-bindings` and `kvm-ioctls` for special locations: 
```bash
git clone https://github.com/MatiasVara/kvm-bindings.git -b add_bindings_for_realms
git clone https://github.com/MatiasVara/kvm-ioctls.git -b cca
```
Then, you compile the cca crate with `cargo build --tests`.

- Run the emulated host with:
```bash
shrinkwrap run cca-3world.yaml --rtvar ROOTFS=~/.shrinkwrap/package/cca-3world/rootfs.ext2 --rtvar SHARE=./ccaforvirtee/
```
- In the emulated host, run the test binary:
```bash
mkdir /cca
mount -t 9p -o trans=virtio,version=9p2000.L FM /cca
cd /cca/cca-forupstream/target/aarch64-unknown-linux-gnu/debug/deps/
./launch-132d83cdd16b0c45
```
You will get something like:
```
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```
and also some outputs from the RMM.

[4] If you want to try in a x86-64 machine, you can cross compile the binary crate by using a container image with the crosscompiler tools:

```dockerfile
FROM debian:latest
RUN rm /bin/sh && ln -s /bin/bash /bin/sh
RUN apt update && apt install -y gcc make gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-aarch64-linux-gnu libc6-dev-arm64-cross curl vim
RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs > install.sh
RUN sh install.sh -y
RUN source "$HOME/.cargo/env" && rustup toolchain install nightly && rustup component add llvm-tools-preview --toolchain nightly && cargo install cargo-llvm-cov && rustup component add llvm-tools-preview --toolchain stable-x86_64-unknown-linux-gnu && rustup target add aarch64-unknown-linux-gnu && rustup toolchain install stable-aarch64-unknown-linux-gnu
ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
#CMD ["cargo", "build", "--target", "aarch64-unknown-linux-gnu"]
#   85  cargo build --tests --target aarch64-unknown-linux-gnu
#   86  cargo test --target aarch64-unknown-linux-gnu
```

[1] https://lore.kernel.org/kvm/20240412165224.GA357251@myrica/T/#md022cbd79ad90384a7e20b71b8fdf288331764b8
[2] https://shrinkwrap.docs.arm.com/en/latest/userguide/configstore/cca-3world.html?highlight=mount#description
[3] https://linaro.atlassian.net/wiki/spaces/QEMU/pages/29051027459/Building+an+RME+stack+for+QEMU#QEMU-VMM